### PR TITLE
Fix version file URL property

### DIFF
--- a/KerbealisticDocking.version
+++ b/KerbealisticDocking.version
@@ -1,6 +1,6 @@
 {
   "NAME": "KerbealisticDocking",
-  "URL": "https://github.com/kurgut/KerbealisticDocking",
+  "URL": "https://raw.githubusercontent.com/kurgut/KerbealisticDocking/main/KerbealisticDocking.version",
   "DOWNLOAD": "https://github.com/kurgut/KerbealisticDocking/releases",
   "GITHUB": {
     "USERNAME": "kurgut",


### PR DESCRIPTION
Hi @kurgut,

The `URL` property of a version file is supposed to point to an online copy of the version file so you can update compatibility after release and/or have KSP-AVC announce available updates. Currently it points to the repo instead.

Now it's fixed. Cheers!

Noticed while reviewing KSP-CKAN/NetKAN#9688.
Same as kurgut/SRCS-Stageable-RCS#1 but for this mod.
